### PR TITLE
Expose calendar API errors

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,12 +35,13 @@ async function checkAvailability() {
   await Promise.all(speakers.map(({ name, calendarId, formUrl }) => {
     const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?key=${API_KEY}&timeMin=${timeMin}&timeMax=${timeMax}&singleEvents=true&orderBy=startTime`;
 
-    return fetch(url)
-      .then(res => res.json().then(data => ({ ok: res.ok, data })))
-      .then(({ ok, data }) => {
-        if (!ok || data.error) {
-          results.push(`<p><strong>${name}</strong>: <span style="color:orange">${T.calendar_private}</span></p>`);
-        } else if (!data.items || data.items.length === 0) {
+      return fetch(url)
+        .then(res => res.json().then(data => ({ ok: res.ok, data })))
+        .then(({ ok, data }) => {
+          if (!ok || data.error) {
+            const msg = (data && data.error && data.error.message) ? data.error.message : T.calendar_private;
+            results.push(`<p><strong>${name}</strong>: <span style="color:orange">${msg}</span></p>`);
+          } else if (!data.items || data.items.length === 0) {
           const request = formUrl ? ` <a href="${formUrl}" target="_blank">${T.request_speaker}</a>` : '';
           results.push(`<p><strong>${name}</strong>: <span style="color:green">${T.available}</span>${request}</p>`);
         } else {
@@ -51,8 +52,9 @@ async function checkAvailability() {
             }).join('') + '</ul>');
         }
       })
-      .catch(() => {
-        results.push(`<p><strong>${name}</strong>: <span style="color:orange">${T.calendar_private}</span></p>`);
+      .catch(err => {
+        const msg = err && err.message ? err.message : T.calendar_private;
+        results.push(`<p><strong>${name}</strong>: <span style="color:orange">${msg}</span></p>`);
       });
   }));
 
@@ -83,11 +85,12 @@ async function checkTeachingRange(startDateInput, endDateInput) {
   await Promise.all(speakers.map(({ name, calendarId, calendarUrl }) => {
     const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?key=${API_KEY}&timeMin=${timeMin}&timeMax=${timeMax}&singleEvents=true&orderBy=startTime`;
 
-    return fetch(url)
-      .then(res => res.json().then(data => ({ ok: res.ok, data })))
-      .then(({ ok, data }) => {
+      return fetch(url)
+        .then(res => res.json().then(data => ({ ok: res.ok, data })))
+        .then(({ ok, data }) => {
         if (!ok || data.error) {
-          results.push(`<p><strong>${name}</strong>: <span style="color:orange">${T.calendar_private}</span></p>`);
+          const msg = (data && data.error && data.error.message) ? data.error.message : T.calendar_private;
+          results.push(`<p><strong>${name}</strong>: <span style="color:orange">${msg}</span></p>`);
         } else if (data.items && data.items.length > 0) {
           const schedule = calendarUrl ? ` <a href="${calendarUrl}" target="_blank">View Calendar</a>` : '';
           results.push(`<p><strong>${name}</strong>${schedule}</p><ul>` +
@@ -98,8 +101,9 @@ async function checkTeachingRange(startDateInput, endDateInput) {
             }).join('') + '</ul>');
         }
       })
-      .catch(() => {
-        results.push(`<p><strong>${name}</strong>: <span style="color:orange">${T.calendar_private}</span></p>`);
+      .catch(err => {
+        const msg = err && err.message ? err.message : T.calendar_private;
+        results.push(`<p><strong>${name}</strong>: <span style="color:orange">${msg}</span></p>`);
       });
   }));
 


### PR DESCRIPTION
## Summary
- show the Google Calendar API error messages instead of the generic "calendar not public" text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f07ec6bfc83218bc67bb4aa08d9b4