### PR TITLE
Improve event table display

### DIFF
--- a/next_week.html
+++ b/next_week.html
@@ -78,8 +78,7 @@
       const start = startOfWeek(today);
       const end = endOfWeek(today);
       setRangeText(start, end);
-      const html = await checkTeachingRange(fmt(start), fmt(end));
-      document.getElementById('results').innerHTML = html;
+      await showEventsRange(fmt(start), fmt(end));
     }
     window.addEventListener('DOMContentLoaded', show);
   </script>

--- a/this_week.html
+++ b/this_week.html
@@ -76,8 +76,7 @@
       const start = startOfWeek(new Date());
       const end = endOfWeek(new Date());
       setRangeText(start, end);
-      const html = await checkTeachingRange(fmt(start), fmt(end));
-      document.getElementById('results').innerHTML = html;
+      await showEventsRange(fmt(start), fmt(end));
     }
     window.addEventListener('DOMContentLoaded', show);
   </script>

--- a/translations.js
+++ b/translations.js
@@ -17,6 +17,13 @@ const translations = {
       "is_teaching": "is TEACHING:",
       "is_available": "is AVAILABLE",
       "calendar_private": "CALENDAR NOT PUBLIC"
+      ,"speaker": "Speaker"
+      ,"event": "Event"
+      ,"start": "Start"
+      ,"end": "End"
+      ,"city": "City"
+      ,"state": "State"
+      ,"country": "Country"
     },
     "es": {
       "title": "Programador de MASCC",
@@ -36,6 +43,13 @@ const translations = {
       "is_teaching": "está ENSEÑANDO:",
       "is_available": "está DISPONIBLE",
       "calendar_private": "CALENDARIO NO PÚBLICO"
+      ,"speaker": "Orador"
+      ,"event": "Evento"
+      ,"start": "Inicio"
+      ,"end": "Fin"
+      ,"city": "Ciudad"
+      ,"state": "Estado"
+      ,"country": "País"
     },
     "pt": {
       "title": "Agendador de MASCC",
@@ -55,6 +69,13 @@ const translations = {
       "is_teaching": "está ENSINANDO:",
       "is_available": "está DISPONÍVEL",
       "calendar_private": "CALENDÁRIO NÃO PÚBLICO"
+      ,"speaker": "Orador"
+      ,"event": "Evento"
+      ,"start": "Início"
+      ,"end": "Fim"
+      ,"city": "Cidade"
+      ,"state": "Estado"
+      ,"country": "País"
     }
   };
 


### PR DESCRIPTION
## Summary
- display weekly and custom schedule results in a unified table
- add translations for table headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f11e89fbc8321aca77bd68f2ad20c