### PR TITLE
Fix flags for spelled out country names

### DIFF
--- a/script.js
+++ b/script.js
@@ -153,9 +153,32 @@ function toDateString(val) {
   return (val || '').split('T')[0];
 }
 
+const COUNTRY_OVERRIDES = {
+  'UNITED STATES': 'US',
+  'UNITED STATES OF AMERICA': 'US',
+  'U.S.A.': 'US',
+  'U.S.A': 'US',
+  'USA': 'US',
+  'U.S.': 'US',
+  'UNITED KINGDOM': 'GB',
+  'UK': 'GB',
+  'U.K.': 'GB',
+  'GREAT BRITAIN': 'GB',
+  'BRASIL': 'BR',
+  'BRAZIL': 'BR',
+  'MEXICO': 'MX',
+  'M\u00c9XICO': 'MX',
+  'SPAIN': 'ES',
+  'ESPA\u00d1A': 'ES',
+  'CANADA': 'CA',
+  'CANAD\u00c1': 'CA'
+};
+
 function flagEmoji(country) {
   if (!country) return '';
-  const cc = country.trim().slice(0, 2).toUpperCase();
+  const key = country.trim().toUpperCase();
+  const override = COUNTRY_OVERRIDES[key];
+  const cc = (override || country.trim().slice(0, 2)).toUpperCase();
   if (cc.length !== 2) return '';
   const base = 0x1f1e6;
   const first = cc.codePointAt(0);

--- a/speakers.html
+++ b/speakers.html
@@ -93,11 +93,35 @@
       document.getElementById('lang-select').value = LANG;
     });
 
+    const COUNTRY_OVERRIDES = {
+      'UNITED STATES': 'US',
+      'UNITED STATES OF AMERICA': 'US',
+      'U.S.A.': 'US',
+      'U.S.A': 'US',
+      'USA': 'US',
+      'U.S.': 'US',
+      'UNITED KINGDOM': 'GB',
+      'UK': 'GB',
+      'U.K.': 'GB',
+      'GREAT BRITAIN': 'GB',
+      'BRASIL': 'BR',
+      'BRAZIL': 'BR',
+      'MEXICO': 'MX',
+      'M\u00c9XICO': 'MX',
+      'SPAIN': 'ES',
+      'ESPA\u00d1A': 'ES',
+      'CANADA': 'CA',
+      'CANAD\u00c1': 'CA'
+    };
+
     function flagEmoji(countryCode) {
       if (!countryCode) return '📍';
-      return countryCode
-        .toUpperCase()
-        .replace(/./g, c => String.fromCodePoint(127397 + c.charCodeAt()));
+      const key = countryCode.trim().toUpperCase();
+      const override = COUNTRY_OVERRIDES[key];
+      const cc = (override || countryCode.trim().slice(0, 2)).toUpperCase();
+      return cc.replace(/./g, c =>
+        String.fromCodePoint(127397 + c.charCodeAt())
+      );
     }
   </script>
 


### PR DESCRIPTION
## Summary
- correct flag lookup when calendar location has country name instead of code
- handle country name overrides for speaker list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f183dba6883219f7a1e1dea2d79e9