### PR TITLE
Add normalized country code for speakers

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,10 +32,14 @@ async function checkAvailability() {
 
   const results = [];
 
-  await Promise.all(speakers.map(({ name, calendarId, formUrl, location }) => {
-    const { city, state, country } = parseLocation(location || '');
-    const parts = [city, state, country].filter(Boolean).join(', ');
-    const loc = parts ? `<br/>${flagFromLocation(location)} ${parts}` : '';
+  await Promise.all(
+    speakers.map(
+      ({ name, calendarId, formUrl, location, normalizedCountryCode }) => {
+        const { city, state, country } = parseLocation(location || '');
+        const parts = [city, state, country].filter(Boolean).join(', ');
+        const loc = parts
+          ? `<br/>${flagEmoji(normalizedCountryCode)} ${parts}`
+          : '';
     const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?key=${API_KEY}&timeMin=${timeMin}&timeMax=${timeMax}&singleEvents=true&orderBy=startTime`;
 
       return fetch(url)
@@ -242,4 +246,5 @@ if (typeof window !== 'undefined') {
   window.checkTeachingRange = checkTeachingRange;
   window.showEventsRange = showEventsRange;
   window.flagFromLocation = flagFromLocation;
+  window.flagEmoji = flagEmoji;
 }

--- a/speakers.html
+++ b/speakers.html
@@ -109,7 +109,7 @@
           const name = `<strong>${speaker.name}</strong>`;
           const calendar = `<a href="${speaker.calendarUrl}" target="_blank">View Calendar</a>`;
           const location = speaker.location
-            ? `<br/>${flagFromLocation(speaker.location)} ${speaker.location}`
+            ? `<br/>${flagEmoji(speaker.normalizedCountryCode)} ${speaker.location}`
             : "";
           const langs = speaker.languages ? `<br/>🗣️ ${speaker.languages.join(', ')}` : "";
           const requestLink = speaker.formUrl

--- a/speakers.json
+++ b/speakers.json
@@ -5,6 +5,8 @@
     "calendarUrl": "https://calendar.google.com/calendar/embed?src=cmm525flhknka2583pafiafb78%40group.calendar.google.com&ctz=America%2FLos_Angeles",
     "location": "Bothell, WA, USA",
     "countryCode": "US",
+    "normalizedCountryCode": "US",
+    "countryCodeInfo": "ISO 3166-1 alpha-2 codes: https://www.iban.com/country-codes",
     "languages": ["English", "Spanish", "Portuguese"],
     "formUrl": "https://docs.google.com/forms/d/e/1FAIpQLSdS6jft3dS_CZQv6wipBniGsXDIKj1cyrTHdyRHUeSV7JNCvA/viewform?usp=pp_url&entry.986885581=Daniel+Munoz"
   }


### PR DESCRIPTION
## Summary
- include normalized country code in `speakers.json`
- use the new code when displaying speaker flags
- expose `flagEmoji` globally for reuse

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f55e6ca048321a7f1739afd4be682