### PR TITLE
Clean up unused strings and helper

### DIFF
--- a/script.js
+++ b/script.js
@@ -200,10 +200,6 @@ function flagEmoji(country) {
   );
 }
 
-function flagFromLocation(loc) {
-  const { country } = parseLocation(loc || '');
-  return flagEmoji(country);
-}
 
 function renderEventsTable(events) {
   let html =
@@ -248,6 +244,5 @@ async function showEventsRange(startDateInput, endDateInput, divId = 'results') 
 if (typeof window !== 'undefined') {
   window.checkTeachingRange = checkTeachingRange;
   window.showEventsRange = showEventsRange;
-  window.flagFromLocation = flagFromLocation;
   window.flagEmoji = flagEmoji;
 }

--- a/translations.js
+++ b/translations.js
@@ -1,7 +1,6 @@
 const translations = {
     "en": {
       "title": "MAWC Scheduler",
-      "home": "Home",
       "list": "📋 List of Speakers & Calendars",
       "availability": "📅 Check Availability by Date Range",
       "teaching": "⏰ Who's Teaching (and where) in a Date Range",
@@ -13,9 +12,6 @@ const translations = {
       "available": "AVAILABLE",
       "request_speaker": "\uD83D\uDCE8 Request this speaker",
       "not_teaching": "NOT teaching during that period",
-      "teaching_now": "TEACHING",
-      "is_teaching": "is TEACHING:",
-      "is_available": "is AVAILABLE",
       "calendar_private": "CALENDAR NOT PUBLIC"
       ,"speaker": "Speaker"
       ,"event": "Event"
@@ -28,7 +24,6 @@ const translations = {
     },
     "es": {
       "title": "Programador de MASCC",
-      "home": "Inicio",
       "list": "📋 Lista de Oradores y Calendarios",
       "availability": "📅 Ver Disponibilidad por Rango de Fechas",
       "teaching": "⏰ Quién Está Enseñando (y dónde) en un Rango de Fechas",
@@ -40,9 +35,6 @@ const translations = {
       "available": "DISPONIBLE",
       "request_speaker": "\uD83D\uDCE8 Solicitar a este orador",
       "not_teaching": "NO está enseñando en ese período",
-      "teaching_now": "ENSEÑANDO",
-      "is_teaching": "está ENSEÑANDO:",
-      "is_available": "está DISPONIBLE",
       "calendar_private": "CALENDARIO NO PÚBLICO"
       ,"speaker": "Orador"
       ,"event": "Evento"
@@ -55,7 +47,6 @@ const translations = {
     },
     "pt": {
       "title": "Agendador de MASCC",
-      "home": "Início",
       "list": "📋 Lista de Oradores e Calendários",
       "availability": "📅 Ver Disponibilidade por Faixa de Datas",
       "teaching": "⏰ Quem Está Ensinando (e onde) em um Intervalo de Datas",
@@ -67,9 +58,6 @@ const translations = {
       "available": "DISPONÍVEL",
       "request_speaker": "\uD83D\uDCE8 Solicitar este orador",
       "not_teaching": "NÃO está ensinando nesse período",
-      "teaching_now": "ENSINANDO",
-      "is_teaching": "está ENSINANDO:",
-      "is_available": "está DISPONÍVEL",
       "calendar_private": "CALENDÁRIO NÃO PÚBLICO"
       ,"speaker": "Orador"
       ,"event": "Evento"


### PR DESCRIPTION
## Summary
- prune unused translations across all languages
- remove unused `flagFromLocation` helper and export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f59c914c88321ab3b5f08858387ba