### PR TITLE
Remove location columns and localize calendar links

### DIFF
--- a/script.js
+++ b/script.js
@@ -138,15 +138,11 @@ async function getEventsInRange(startDateInput, endDateInput) {
             data.items.forEach(e => {
               const start = e.start.dateTime || e.start.date;
               const end = e.end.dateTime || e.end.date;
-              const { city, state, country } = parseLocation(e.location || '');
               events.push({
                 speaker: name,
                 event: e.summary,
                 start,
                 end,
-                city,
-                state,
-                country,
                 calendarUrl
               });
             });
@@ -208,9 +204,6 @@ function renderEventsTable(events) {
     `<th>${T.event}</th>` +
     `<th>${T.start}</th>` +
     `<th>${T.end}</th>` +
-    `<th>${T.city}</th>` +
-    `<th>${T.state}</th>` +
-    `<th>${T.country}</th>` +
     `<th>${T.calendar}</th>` +
     '</tr></thead><tbody>';
   if (events.length) {
@@ -221,14 +214,11 @@ function renderEventsTable(events) {
         `<td>${e.event}</td>` +
         `<td>${toDateString(e.start)}</td>` +
         `<td>${toDateString(e.end)}</td>` +
-        `<td>${e.city}</td>` +
-        `<td>${e.state}</td>` +
-        `<td>${flagEmoji(e.country)} ${e.country}</td>` +
-        `<td><a href="${e.calendarUrl}" target="_blank">${T.calendar}</a></td>` +
+        `<td><a href="${e.calendarUrl}" target="_blank">${T.view_calendar}</a></td>` +
         '</tr>';
     });
   } else {
-    html += `<tr><td colspan="8">${T.not_teaching}</td></tr>`;
+    html += `<tr><td colspan="5">${T.not_teaching}</td></tr>`;
   }
   html += '</tbody></table>';
   return html;

--- a/speakers.html
+++ b/speakers.html
@@ -107,13 +107,13 @@
         const ul = document.getElementById('speakerList');
         data.forEach(speaker => {
           const name = `<strong>${speaker.name}</strong>`;
-          const calendar = `<a href="${speaker.calendarUrl}" target="_blank">View Calendar</a>`;
+          const calendar = `<a href="${speaker.calendarUrl}" target="_blank">${T.view_calendar}</a>`;
           const location = speaker.location
             ? `<br/>${flagEmoji(speaker.normalizedCountryCode)} ${speaker.location}`
             : "";
           const langs = speaker.languages ? `<br/>🗣️ ${speaker.languages.join(', ')}` : "";
           const requestLink = speaker.formUrl
-            ? `<br/><a href="${speaker.formUrl}" target="_blank">📨 Request this speaker</a>`
+            ? `<br/><a href="${speaker.formUrl}" target="_blank">${T.request_speaker}</a>`
             : "";
           const li = document.createElement('li');
           li.innerHTML = `${name} – ${calendar}${location}${langs}${requestLink}`;

--- a/translations.js
+++ b/translations.js
@@ -17,10 +17,8 @@ const translations = {
       ,"event": "Event"
       ,"start": "Start"
       ,"end": "End"
-      ,"city": "City"
-      ,"state": "State"
-      ,"country": "Country"
       ,"calendar": "Calendar"
+      ,"view_calendar": "View Calendar"
     },
     "es": {
       "title": "Programador de MASCC",
@@ -40,10 +38,8 @@ const translations = {
       ,"event": "Evento"
       ,"start": "Inicio"
       ,"end": "Fin"
-      ,"city": "Ciudad"
-      ,"state": "Estado"
-      ,"country": "País"
       ,"calendar": "Calendario"
+      ,"view_calendar": "Ver Calendario"
     },
     "pt": {
       "title": "Agendador de MASCC",
@@ -63,10 +59,8 @@ const translations = {
       ,"event": "Evento"
       ,"start": "Início"
       ,"end": "Fim"
-      ,"city": "Cidade"
-      ,"state": "Estado"
-      ,"country": "País"
       ,"calendar": "Calendário"
+      ,"view_calendar": "Ver Calendário"
     }
   };
 


### PR DESCRIPTION
## Summary
- Drop City/State/Country columns from events table
- Localize "View Calendar" and "Request this speaker" links
- Clean up translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689174b1b00c83218fc790fe9fd59fc5