### PR TITLE
Refactor week helpers and remove unused code

### DIFF
--- a/next_week.html
+++ b/next_week.html
@@ -53,33 +53,13 @@
   <div id="results"></div>
   <script src="script.js"></script>
   <script>
-    function startOfWeek(date){
-      const d = new Date(date);
-      const day = d.getDay();
-      const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-      d.setDate(diff);
-      d.setHours(0,0,0,0);
-      return d;
-    }
-    function endOfWeek(date){
-      const start = startOfWeek(date);
-      const end = new Date(start);
-      end.setDate(start.getDate()+6);
-      return end;
-    }
-    function fmt(d){
-      return d.toISOString().split('T')[0];
-    }
-    function setRangeText(start, end){
-      document.getElementById('range').textContent = `${fmt(start)} - ${fmt(end)}`;
-    }
     async function show(){
       const today = new Date();
       today.setDate(today.getDate()+7);
       const start = startOfWeek(today);
       const end = endOfWeek(today);
       setRangeText(start, end);
-      await showEventsRange(fmt(start), fmt(end));
+      await showEventsRange(formatDate(start), formatDate(end));
     }
     window.addEventListener('DOMContentLoaded', show);
   </script>

--- a/script.js
+++ b/script.js
@@ -79,11 +79,6 @@ async function checkTeaching() {
   await showEventsRange(startDateInput, endDateInput);
 }
 
-async function checkTeachingRange(startDateInput, endDateInput) {
-  const events = await getEventsInRange(startDateInput, endDateInput);
-  return renderEventsTable(events);
-}
-
 const US_STATES = new Set([
   'AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA','HI','ID','IL','IN','IA','KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN','TX','UT','VT','VA','WA','WV','WI','WY','DC'
 ]);
@@ -159,6 +154,33 @@ function toDateString(val) {
   return (val || '').split('T')[0];
 }
 
+function formatDate(date) {
+  return date.toISOString().split('T')[0];
+}
+
+function startOfWeek(date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  d.setDate(diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function endOfWeek(date) {
+  const start = startOfWeek(date);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  return end;
+}
+
+function setRangeText(start, end, rangeId = 'range') {
+  const el = document.getElementById(rangeId);
+  if (el) {
+    el.textContent = `${formatDate(start)} - ${formatDate(end)}`;
+  }
+}
+
 const COUNTRY_OVERRIDES = {
   'UNITED STATES': 'US',
   'UNITED STATES OF AMERICA': 'US',
@@ -232,7 +254,10 @@ async function showEventsRange(startDateInput, endDateInput, divId = 'results') 
 }
 
 if (typeof window !== 'undefined') {
-  window.checkTeachingRange = checkTeachingRange;
   window.showEventsRange = showEventsRange;
   window.flagEmoji = flagEmoji;
+  window.startOfWeek = startOfWeek;
+  window.endOfWeek = endOfWeek;
+  window.formatDate = formatDate;
+  window.setRangeText = setRangeText;
 }

--- a/this_week.html
+++ b/this_week.html
@@ -53,31 +53,11 @@
   <div id="results"></div>
   <script src="script.js"></script>
   <script>
-    function startOfWeek(date){
-      const d = new Date(date);
-      const day = d.getDay();
-      const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-      d.setDate(diff);
-      d.setHours(0,0,0,0);
-      return d;
-    }
-    function endOfWeek(date){
-      const start = startOfWeek(date);
-      const end = new Date(start);
-      end.setDate(start.getDate()+6);
-      return end;
-    }
-    function fmt(d){
-      return d.toISOString().split('T')[0];
-    }
-    function setRangeText(start, end){
-      document.getElementById('range').textContent = `${fmt(start)} - ${fmt(end)}`;
-    }
     async function show(){
       const start = startOfWeek(new Date());
       const end = endOfWeek(new Date());
       setRangeText(start, end);
-      await showEventsRange(fmt(start), fmt(end));
+      await showEventsRange(formatDate(start), formatDate(end));
     }
     window.addEventListener('DOMContentLoaded', show);
   </script>


### PR DESCRIPTION
## Summary
- remove unused `checkTeachingRange` helper
- centralize week calculations in `script.js`
- simplify week pages by using shared helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891797257d48321a8e81a88897dfe56