### PR TITLE
Add language dropdown to all pages

### DIFF
--- a/availability.html
+++ b/availability.html
@@ -5,18 +5,7 @@
   <meta charset="UTF-8" />
   <title>Availability by Date Range</title>
   <script src="translations.js"></script>
-  <script>
-    let langParam = new URLSearchParams(window.location.search).get('lang');
-    let browserLang = (navigator.language || 'en').slice(0, 2).toLowerCase();
-    const LANG = ['en', 'es', 'pt'].includes((langParam || browserLang)) ? (langParam || browserLang) : 'en';
-    const T = {};
-    function setLanguageStrings() {
-      for (const [key, value] of Object.entries(translations[LANG] || translations['en'])) {
-        T[key] = value;
-      }
-    }
-    setLanguageStrings();
-  </script>
+  <script src="lang.js"></script>
   <style>
     body {
       font-family: sans-serif;
@@ -47,6 +36,7 @@
 </head>
 
 <body>
+  
   <p><script>document.write(`<a href="index.html?lang=${LANG}">${T.home}</a>`);</script></p>
   <h1>
     <script>document.write(T.availability)</script>

--- a/index.html
+++ b/index.html
@@ -58,41 +58,15 @@
   </style>
 
   <script src="translations.js"></script>
+  <script src="lang.js"></script>
   <script>
-    let langParam = new URLSearchParams(window.location.search).get('lang');
-    let browserLang = (navigator.language || 'en').slice(0, 2).toLowerCase();
-    const LANG = ['en', 'es', 'pt'].includes((langParam || browserLang)) ? (langParam || browserLang) : 'en';
-    const T = {};
-    function setLanguageStrings() {
-      for (const [key, value] of Object.entries(translations[LANG] || translations['en'])) {
-        T[key] = value;
-      }
-    }
-    setLanguageStrings();
     document.title = T.title;
   </script>
 </head>
 
 <body id="index">
 
-  <div style="margin-bottom: 1em;">
-    <label for="lang-select">🌐 Language: </label>
-    <select id="lang-select" onchange="changeLang(this.value)">
-      <option value="en">English</option>
-      <option value="es">Español</option>
-      <option value="pt">Português</option>
-    </select>
-  </div>
-  <script>
-    function changeLang(lang) {
-      const url = new URL(window.location.href);
-      url.searchParams.set('lang', lang);
-      window.location.href = url.toString();
-    }
-    window.addEventListener("DOMContentLoaded", () => {
-      document.getElementById('lang-select').value = LANG;
-    });
-  </script>
+
 
 
   <h1>

--- a/lang.js
+++ b/lang.js
@@ -1,0 +1,38 @@
+let langParam = new URLSearchParams(window.location.search).get('lang');
+let browserLang = (navigator.language || 'en').slice(0,2).toLowerCase();
+const LANG = ['en','es','pt'].includes((langParam || browserLang)) ? (langParam || browserLang) : 'en';
+const T = {};
+
+for (const [key, value] of Object.entries(translations[LANG] || translations['en'])) {
+  T[key] = value;
+}
+
+function changeLang(lang) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('lang', lang);
+  window.location.href = url.toString();
+}
+
+function renderLanguageSelector() {
+  const div = document.createElement('div');
+  div.style.marginBottom = '1em';
+  div.innerHTML = `
+    <label for="lang-select">🌐 Language: </label>
+    <select id="lang-select">
+      <option value="en">English</option>
+      <option value="es">Español</option>
+      <option value="pt">Português</option>
+    </select>
+  `;
+  document.body.prepend(div);
+  const select = div.querySelector('#lang-select');
+  select.value = LANG;
+  select.addEventListener('change', (e) => changeLang(e.target.value));
+}
+
+window.addEventListener('DOMContentLoaded', renderLanguageSelector);
+
+// expose globals
+window.LANG = LANG;
+window.T = T;
+window.changeLang = changeLang;

--- a/next_week.html
+++ b/next_week.html
@@ -4,17 +4,8 @@
   <meta charset="UTF-8" />
   <title>Week</title>
   <script src="translations.js"></script>
+  <script src="lang.js"></script>
   <script>
-    let langParam = new URLSearchParams(window.location.search).get('lang');
-    let browserLang = (navigator.language || 'en').slice(0,2).toLowerCase();
-    const LANG = ['en','es','pt'].includes((langParam || browserLang)) ? (langParam || browserLang) : 'en';
-    const T = {};
-    function setLanguageStrings(){
-      for(const [key,value] of Object.entries(translations[LANG] || translations['en'])){
-        T[key]=value;
-      }
-    }
-    setLanguageStrings();
     document.title = T.next_week;
   </script>
   <style>
@@ -46,6 +37,7 @@
   </style>
 </head>
 <body>
+  
   <p><script>document.write(`<a href="index.html?lang=${LANG}">${T.home}</a>`);</script></p>
   <h1 id="title"></h1>
   <script>document.getElementById('title').textContent = T.next_week;</script>

--- a/speakers.html
+++ b/speakers.html
@@ -58,42 +58,16 @@
   </style>
 
   <script src="translations.js"></script>
+  <script src="lang.js"></script>
   <script src="script.js"></script>
   <script>
-    let langParam = new URLSearchParams(window.location.search).get('lang');
-    let browserLang = (navigator.language || 'en').slice(0, 2).toLowerCase();
-    const LANG = ['en', 'es', 'pt'].includes((langParam || browserLang)) ? (langParam || browserLang) : 'en';
-    const T = {};
-    function setLanguageStrings() {
-      for (const [key, value] of Object.entries(translations[LANG] || translations['en'])) {
-        T[key] = value;
-      }
-    }
-    setLanguageStrings();
     document.title = T.list;
   </script>
 </head>
 
 <body id="speakers">
 
-  <div style="margin-bottom: 1em;">
-    <label for="lang-select">🌐 Language: </label>
-    <select id="lang-select" onchange="changeLang(this.value)">
-      <option value="en">English</option>
-      <option value="es">Español</option>
-      <option value="pt">Português</option>
-    </select>
-  </div>
-  <script>
-    function changeLang(lang) {
-      const url = new URL(window.location.href);
-      url.searchParams.set('lang', lang);
-      window.location.href = url.toString();
-    }
-    window.addEventListener("DOMContentLoaded", () => {
-      document.getElementById('lang-select').value = LANG;
-    });
-  </script>
+  
   <p><script>document.write(`<a href="index.html?lang=${LANG}">${T.home}</a>`);</script></p>
 
   <h1>

--- a/teaching.html
+++ b/teaching.html
@@ -5,18 +5,7 @@
   <meta charset="UTF-8" />
   <title>Teaching in Date Range</title>
   <script src="translations.js"></script>
-  <script>
-    let langParam = new URLSearchParams(window.location.search).get('lang');
-    let browserLang = (navigator.language || 'en').slice(0, 2).toLowerCase();
-    const LANG = ['en', 'es', 'pt'].includes((langParam || browserLang)) ? (langParam || browserLang) : 'en';
-    const T = {};
-    function setLanguageStrings() {
-      for (const [key, value] of Object.entries(translations[LANG] || translations['en'])) {
-        T[key] = value;
-      }
-    }
-    setLanguageStrings();
-  </script>
+  <script src="lang.js"></script>
   <style>
     body {
       font-family: sans-serif;
@@ -47,6 +36,7 @@
 </head>
 
 <body>
+  
   <p><script>document.write(`<a href="index.html?lang=${LANG}">${T.home}</a>`);</script></p>
   <h1>
     <script>document.write(T.teaching)</script>

--- a/this_week.html
+++ b/this_week.html
@@ -4,17 +4,8 @@
   <meta charset="UTF-8" />
   <title>Week</title>
   <script src="translations.js"></script>
+  <script src="lang.js"></script>
   <script>
-    let langParam = new URLSearchParams(window.location.search).get('lang');
-    let browserLang = (navigator.language || 'en').slice(0,2).toLowerCase();
-    const LANG = ['en','es','pt'].includes((langParam || browserLang)) ? (langParam || browserLang) : 'en';
-    const T = {};
-    function setLanguageStrings(){
-      for(const [key,value] of Object.entries(translations[LANG] || translations['en'])){
-        T[key]=value;
-      }
-    }
-    setLanguageStrings();
     document.title = T.this_week;
   </script>
   <style>
@@ -46,6 +37,7 @@
   </style>
 </head>
 <body>
+  
   <p><script>document.write(`<a href="index.html?lang=${LANG}">${T.home}</a>`);</script></p>
   <h1 id="title"></h1>
   <script>document.getElementById('title').textContent = T.this_week;</script>


### PR DESCRIPTION
## Summary
- Extract language selector into shared `lang.js` and inject dropdown across pages
- Remove duplicated language initialization scripts from each page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68917f3244d8832194da6fd16e16bdd3