### PR TITLE
feat: add follow calendar links

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,6 +7,10 @@ function getCalendarUrl(calendarId) {
   return `https://calendar.google.com/calendar/embed?src=${encodeURIComponent(calendarId)}`;
 }
 
+function getFollowUrl(calendarId) {
+  return `https://calendar.google.com/calendar/ical/${encodeURIComponent(calendarId)}/public/basic.ics`;
+}
+
 async function speakers() {
   if (!speakersCache) {
     const res = await fetch('speakers.json');
@@ -150,7 +154,8 @@ async function getEventsInRange(startDateInput, endDateInput) {
                 event: e.summary,
                 start,
                 end,
-                calendarUrl: getCalendarUrl(calendarId)
+                calendarUrl: getCalendarUrl(calendarId),
+                followUrl: getFollowUrl(calendarId)
               });
             });
           }
@@ -248,7 +253,7 @@ function renderEventsTable(events) {
         `<td>${e.event}</td>` +
         `<td>${toDateString(e.start)}</td>` +
         `<td>${toDateString(e.end)}</td>` +
-        `<td><a href="${e.calendarUrl}" target="_blank">${T.view_calendar}</a></td>` +
+        `<td><a href="${e.calendarUrl}" target="_blank">${T.view_calendar}</a> | <a href="${e.followUrl}" target="_blank">${T.follow_calendar}</a></td>` +
         '</tr>';
     });
   } else {
@@ -273,5 +278,6 @@ if (typeof window !== 'undefined') {
   window.formatDate = formatDate;
   window.setRangeText = setRangeText;
   window.getCalendarUrl = getCalendarUrl;
+  window.getFollowUrl = getFollowUrl;
   window.speakers = speakers;
 }

--- a/speakers.html
+++ b/speakers.html
@@ -79,7 +79,7 @@
         const ul = document.getElementById('speakerList');
         data.forEach(speaker => {
           const name = `<strong>${speaker.name}</strong>`;
-          const calendar = `<a href="${getCalendarUrl(speaker.calendarId)}" target="_blank">${T.view_calendar}</a>`;
+          const calendar = `<a href="${getCalendarUrl(speaker.calendarId)}" target="_blank">${T.view_calendar}</a> | <a href="${getFollowUrl(speaker.calendarId)}" target="_blank">${T.follow_calendar}</a>`;
           const location = speaker.location
             ? `<br/>${flagEmoji(speaker.normalizedCountryCode)} ${speaker.location}`
             : "";

--- a/translations.js
+++ b/translations.js
@@ -20,6 +20,7 @@ const translations = {
       ,"end": "End"
       ,"calendar": "Calendar"
       ,"view_calendar": "View Calendar"
+      ,"follow_calendar": "Follow Calendar"
     },
     "es": {
       "title": "Programador de MASCC",
@@ -42,6 +43,7 @@ const translations = {
       ,"end": "Fin"
       ,"calendar": "Calendario"
       ,"view_calendar": "Ver Calendario"
+      ,"follow_calendar": "Seguir Calendario"
     },
     "pt": {
       "title": "Agendador de MASCC",
@@ -64,6 +66,7 @@ const translations = {
       ,"end": "Fim"
       ,"calendar": "Calendário"
       ,"view_calendar": "Ver Calendário"
+      ,"follow_calendar": "Seguir Calendário"
     }
   };
 


### PR DESCRIPTION
## Summary
- add follow-calendar ICS link alongside view-calendar
- translate new follow-calendar label in EN/ES/PT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689241eb058083219df2f947a1f6fe42