### PR TITLE
Refine calendar link presentation

### DIFF
--- a/script.js
+++ b/script.js
@@ -243,7 +243,8 @@ function renderEventsTable(events) {
     `<th>${T.event}</th>` +
     `<th>${T.start}</th>` +
     `<th>${T.end}</th>` +
-    `<th>${T.calendar}</th>` +
+    `<th>${T.view_calendar}</th>` +
+    `<th>${T.follow_calendar}</th>` +
     '</tr></thead><tbody>';
   if (events.length) {
     events.forEach(e => {
@@ -253,11 +254,12 @@ function renderEventsTable(events) {
         `<td>${e.event}</td>` +
         `<td>${toDateString(e.start)}</td>` +
         `<td>${toDateString(e.end)}</td>` +
-        `<td><a href="${e.calendarUrl}" target="_blank">${T.view_calendar}</a> | <a href="${e.followUrl}" target="_blank">${T.follow_calendar}</a></td>` +
+        `<td><a href="${e.calendarUrl}" target="_blank">${T.view_calendar}</a></td>` +
+        `<td><a href="${e.followUrl}" target="_blank">${T.follow_calendar}</a></td>` +
         '</tr>';
     });
   } else {
-    html += `<tr><td colspan="5">${T.not_teaching}</td></tr>`;
+    html += `<tr><td colspan="6">${T.not_teaching}</td></tr>`;
   }
   html += '</tbody></table>';
   return html;

--- a/speakers.html
+++ b/speakers.html
@@ -79,7 +79,7 @@
         const ul = document.getElementById('speakerList');
         data.forEach(speaker => {
           const name = `<strong>${speaker.name}</strong>`;
-          const calendar = `<a href="${getCalendarUrl(speaker.calendarId)}" target="_blank">${T.view_calendar}</a> | <a href="${getFollowUrl(speaker.calendarId)}" target="_blank">${T.follow_calendar}</a>`;
+          const calendarLinks = `<a href="${getCalendarUrl(speaker.calendarId)}" target="_blank">${T.view_calendar}</a> | <a href="${getFollowUrl(speaker.calendarId)}" target="_blank">${T.follow_calendar}</a>`;
           const location = speaker.location
             ? `<br/>${flagEmoji(speaker.normalizedCountryCode)} ${speaker.location}`
             : "";
@@ -88,7 +88,7 @@
             ? `<br/><a href="${speaker.formUrl}" target="_blank">${T.request_speaker}</a>`
             : "";
           const li = document.createElement('li');
-          li.innerHTML = `${name} – ${calendar}${location}${langs}${requestLink}`;
+          li.innerHTML = `${name}${location}${langs}<br/>${calendarLinks}${requestLink}`;
           ul.appendChild(li);
         });
       });


### PR DESCRIPTION
## Summary
- Move speaker calendar links onto their own line below language listings.
- Split event tables into separate View Calendar and Follow Calendar columns with translated headers.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892451bc3ac8321ba943b0d751edffa