### PR TITLE
Ignore 'ocupado' events in teaching views

### DIFF
--- a/script.js
+++ b/script.js
@@ -147,6 +147,12 @@ async function getEventsInRange(startDateInput, endDateInput) {
         .then(({ ok, data }) => {
           if (ok && data.items) {
             data.items.forEach(e => {
+              const firstWord = ((e.summary || '')
+                .trim()
+                .split(/\s+/)[0] || '')
+                .toLowerCase();
+              if (firstWord === 'ocupado') return;
+
               const start = e.start.dateTime || e.start.date;
               const end = e.end.dateTime || e.end.date;
               events.push({


### PR DESCRIPTION
## Summary
- skip events marked with `ocupado` when gathering speaker events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892c0a691d88321a54f94cb503fc2b6