### PR TITLE
Skip empty periods and remove unused translation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -12,7 +12,6 @@
   "loading": "Loading...",
   "available": "AVAILABLE",
   "request_speaker": "\uD83D\uDCE8 Request this speaker",
-  "not_teaching": "NOT teaching during that period",
   "calendar_private": "CALENDAR NOT PUBLIC",
   "speaker": "Speaker",
   "event": "Event",

--- a/locales/es.json
+++ b/locales/es.json
@@ -12,7 +12,6 @@
   "loading": "Cargando...",
   "available": "DISPONIBLE",
   "request_speaker": "\uD83D\uDCE8 Solicitar este orador",
-  "not_teaching": "NO est\u00E1 ense\u00F1ando en ese per\u00EDodo",
   "calendar_private": "CALENDARIO NO P\u00DABLICO",
   "speaker": "Orador",
   "event": "Evento",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -12,7 +12,6 @@
   "loading": "Carregando...",
   "available": "DISPON\u00CDVEL",
   "request_speaker": "\uD83D\uDCE8 Solicitar este orador",
-  "not_teaching": "N\u00C3O est\u00E1 ensinando nesse per\u00EDodo",
   "calendar_private": "CALEND\u00C1RIO N\u00C3O P\u00DABLICO",
   "speaker": "Orador",
   "event": "Evento",

--- a/script.js
+++ b/script.js
@@ -208,8 +208,8 @@ function hasEventInRange(items, start, end) {
 }
 
 async function getEventsInRange(startDateInput, endDateInput) {
-  const timeMin = new Date(startDateInput).toISOString();
-  const endDate = new Date(endDateInput);
+  const timeMin = new Date(`${startDateInput}T00:00:00`).toISOString();
+  const endDate = new Date(`${endDateInput}T00:00:00`);
   endDate.setDate(endDate.getDate() + 1);
   const timeMax = endDate.toISOString();
 
@@ -352,8 +352,8 @@ function formatShortRange(start, end) {
 }
 
 function renderEventsList(events, startDateInput, endDateInput) {
-  const start = new Date(startDateInput);
-  const end = new Date(endDateInput);
+  const start = new Date(`${startDateInput}T00:00:00`);
+  const end = new Date(`${endDateInput}T00:00:00`);
   const weeks = [];
   let current = startOfWeek(start);
   while (current <= end) {
@@ -374,25 +374,22 @@ function renderEventsList(events, startDateInput, endDateInput) {
 
   const html = [];
   weeks.forEach(w => {
+    if (!w.events.length) return;
     html.push(
       `<h3>${formatDisplayDate(w.weekStart)} - ${formatDisplayDate(
         w.weekEnd
       )}</h3>`
     );
-    if (w.events.length) {
-      html.push('<ol>');
-      w.events.forEach(e => {
-        html.push(
-          `<li>${e.event} - ${e.speaker} (<a href="${e.calendarUrl}" target="_blank">${T.calendar}</a>) ${formatShortRange(
-            e.start,
-            e.end
-          )}</li>`
-        );
-      });
-      html.push('</ol>');
-    } else {
-      html.push(`<p>${T.not_teaching}</p>`);
-    }
+    html.push('<ol>');
+    w.events.forEach(e => {
+      html.push(
+        `<li>${e.event} - ${e.speaker} (<a href="${e.calendarUrl}" target="_blank">${T.calendar}</a>) ${formatShortRange(
+          e.start,
+          e.end
+        )}</li>`
+      );
+    });
+    html.push('</ol>');
   });
   return html.join('');
 }


### PR DESCRIPTION
## Summary
- Avoid listing weeks with no teaching events
- Parse date strings as local dates to prevent stray previous week
- Drop unused `not_teaching` translation strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b0ca82dc8321a0f9e26621a6597b