### PR TITLE
chore: remove unused calendar translation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -19,7 +19,6 @@
   "end": "End",
   "view_calendar": "View Calendar",
   "follow_calendar": "Follow Calendar",
-  "calendar": "Calendar",
   "must_be_available_entire_range": "Must be available for the entire range",
   "none_available": "No speakers available",
   "document_link": "https://docs.google.com/document/d/1DA43ee8d6fvvf8PvauI7GbMJQ_Tyzd_e1ie6qB72zhY/",

--- a/locales/es.json
+++ b/locales/es.json
@@ -19,7 +19,6 @@
   "end": "Fin",
   "view_calendar": "Ver Calendario",
   "follow_calendar": "Seguir Calendario",
-  "calendar": "Calendario",
   "must_be_available_entire_range": "Debe estar disponible durante todo el rango",
   "none_available": "No hay oradores disponibles",
   "document_link": "https://docs.google.com/document/d/12r9yETGDjLMo9Nb8zbbkT4BreQrCAEy9mfirN-b7_cE/",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -19,7 +19,6 @@
   "end": "Fim",
   "view_calendar": "Ver Calend\u00E1rio",
   "follow_calendar": "Seguir Calend\u00E1rio",
-  "calendar": "Calend\u00E1rio",
   "must_be_available_entire_range": "Deve estar dispon\u00EDvel durante todo o intervalo",
   "none_available": "Nenhum orador dispon\u00EDvel",
   "document_link": "https://docs.google.com/document/d/1-j6IjAytS1a-RnwRNrzXyqbqcEDxUwDz2IBwrke2O1s/",


### PR DESCRIPTION
## Summary
- remove unused `calendar` translation key from all locales

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b6522e608321b5f75ba950012770