### PR TITLE
Stabilize page scripts and expose availability helpers

### DIFF
--- a/next_week.html
+++ b/next_week.html
@@ -8,20 +8,27 @@
   <script src="https://unpkg.com/i18next@23.4.9/dist/umd/i18next.min.js"></script>
   <script src="https://unpkg.com/i18next-http-backend@2.4.1/i18nextHttpBackend.min.js"></script>
   <script src="app.js"></script>
-  <script type="module" src="script.js"></script>
 </head>
 <body>
   <h1 id="title" data-i18n-key="next_week"></h1>
   <p id="range"></p>
   <div id="results"></div>
-  <script>
-    document.addEventListener('i18nReady', () => {
+  <script type="module">
+    import { startOfWeek, endOfWeek, showEventsRange, formatDate } from './script.js';
+
+    const run = () => {
       const today = new Date();
       today.setDate(today.getDate() + 7);
       const start = startOfWeek(today);
       const end = endOfWeek(today);
       showEventsRange(formatDate(start), formatDate(end));
-    });
+    };
+
+    if (window.i18next?.isInitialized) {
+      run();
+    } else {
+      document.addEventListener('i18nReady', run, { once: true });
+    }
   </script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -415,4 +415,6 @@ if (typeof window !== 'undefined') {
   window.getCalendarUrl = getCalendarUrl;
   window.getFollowUrl = getFollowUrl;
   window.speakers = speakers;
+  window.checkAvailability = checkAvailability;
+  window.checkTeaching = checkTeaching;
 }

--- a/speakers.html
+++ b/speakers.html
@@ -8,27 +8,34 @@
   <script src="https://unpkg.com/i18next@23.4.9/dist/umd/i18next.min.js"></script>
   <script src="https://unpkg.com/i18next-http-backend@2.4.1/i18nextHttpBackend.min.js"></script>
   <script src="app.js"></script>
-  <script type="module" src="script.js"></script>
 </head>
-<body id="speakers">
+<body>
   <h1 data-i18n-key="list"></h1>
   <ul id="speakerList"></ul>
-  <script>
-    document.addEventListener('i18nReady', () => {
+  <script type="module">
+    import { speakers, getCalendarUrl, getFollowUrl, flagEmoji } from './script.js';
+
+    const render = () => {
       speakers().then(data => {
         const ul = document.getElementById('speakerList');
         data.forEach(speaker => {
           const name = `<strong>${speaker.name}</strong>`;
           const calendarLinks = `<a href="${getCalendarUrl(speaker.calendarId)}" target="_blank">${T.view_calendar}</a> | <a href="${getFollowUrl(speaker.calendarId)}" target="_blank">${T.follow_calendar}</a>`;
-          const location = speaker.location ? `<br/>${flagEmoji(speaker.normalizedCountryCode)} ${speaker.location}` : "";
-          const langs = speaker.languages ? `<br/>🗣️ ${speaker.languages.join(', ')}` : "";
-          const requestLink = speaker.formUrl ? `<br/><a href="${speaker.formUrl}" target="_blank">${T.request_speaker}</a>` : "";
+          const location = speaker.location ? `<br/>${flagEmoji(speaker.normalizedCountryCode)} ${speaker.location}` : '';
+          const langs = speaker.languages ? `<br/>🗣️ ${speaker.languages.join(', ')}` : '';
+          const requestLink = speaker.formUrl ? `<br/><a href="${speaker.formUrl}" target="_blank">${T.request_speaker}</a>` : '';
           const li = document.createElement('li');
           li.innerHTML = `${name}${location}${langs}<br/>${calendarLinks}${requestLink}`;
           ul.appendChild(li);
         });
       });
-    });
+    };
+
+    if (window.i18next?.isInitialized) {
+      render();
+    } else {
+      document.addEventListener('i18nReady', render, { once: true });
+    }
   </script>
 </body>
 </html>

--- a/this_week.html
+++ b/this_week.html
@@ -8,18 +8,25 @@
   <script src="https://unpkg.com/i18next@23.4.9/dist/umd/i18next.min.js"></script>
   <script src="https://unpkg.com/i18next-http-backend@2.4.1/i18nextHttpBackend.min.js"></script>
   <script src="app.js"></script>
-  <script type="module" src="script.js"></script>
 </head>
 <body>
   <h1 id="title" data-i18n-key="this_week"></h1>
   <p id="range"></p>
   <div id="results"></div>
-  <script>
-    document.addEventListener('i18nReady', () => {
+  <script type="module">
+    import { startOfWeek, endOfWeek, showEventsRange, formatDate } from './script.js';
+
+    const run = () => {
       const start = startOfWeek(new Date());
       const end = endOfWeek(new Date());
       showEventsRange(formatDate(start), formatDate(end));
-    });
+    };
+
+    if (window.i18next?.isInitialized) {
+      run();
+    } else {
+      document.addEventListener('i18nReady', run, { once: true });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Export availability and teaching check helpers so buttons work
- Load page-specific modules after i18n is ready to avoid race conditions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c5fdc4ec8321935fc96b38c8b137