### PR TITLE
Sort weekly events alphabetically

### DIFF
--- a/script.js
+++ b/script.js
@@ -377,6 +377,7 @@ function renderEventsList(events, startDateInput, endDateInput) {
   const html = [];
   weeks.forEach(w => {
     if (!w.events.length) return;
+    w.events.sort((a, b) => (a.event || '').localeCompare(b.event || ''));
     html.push(
       `<h3>${formatDisplayDate(w.weekStart)} - ${formatDisplayDate(
         w.weekEnd


### PR DESCRIPTION
## Summary
- order weekly event lists alphabetically so countries appear grouped in order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c7f7d86c8321a6bb166f52199c35