### PR TITLE
Fix module loading in weekly views

### DIFF
--- a/next_week.html
+++ b/next_week.html
@@ -14,7 +14,7 @@
   <p id="range"></p>
   <div id="results"></div>
   <script type="module">
-    import { startOfWeek, endOfWeek, showEventsRange, formatDate } from './script.js';
+    import './script.js';
 
     const run = () => {
       const today = new Date();

--- a/this_week.html
+++ b/this_week.html
@@ -14,7 +14,7 @@
   <p id="range"></p>
   <div id="results"></div>
   <script type="module">
-    import { startOfWeek, endOfWeek, showEventsRange, formatDate } from './script.js';
+    import './script.js';
 
     const run = () => {
       const start = startOfWeek(new Date());


### PR DESCRIPTION
## Summary
- load `script.js` for its side effects in weekly pages to avoid missing export errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c970f84c8321a25dcc8e0e9f4917