### PR TITLE
Avoid duplicate dots after event names

### DIFF
--- a/script.js
+++ b/script.js
@@ -387,8 +387,10 @@ function renderEventsList(events, startDateInput, endDateInput) {
     w.events.forEach(e => {
       const country = ((e.event || '').trim().split(/[^A-Za-zÀ-ÿ]+/)[0]) || '';
       const flag = flagEmoji(getCountryCode(country));
+      const eventName = (e.event || '').trim();
+      const eventDisplay = eventName && !eventName.endsWith('.') ? eventName + '.' : eventName;
       html.push(
-        `<li>${flag ? flag + ' ' : ''}${e.event}. ${e.speaker} (${formatShortRange(
+        `<li>${flag ? flag + ' ' : ''}${eventDisplay} ${e.speaker} (${formatShortRange(
           e.start,
           e.end
         )})</li>`


### PR DESCRIPTION
## Summary
- Only append a dot after event names if one isn't already present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d13ecd5c8321852d39851c55aa19