### PR TITLE
Reload page on language change

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,10 +45,9 @@
 
   function changeLang(lang) {
     setCookie('lang', lang);
-    i18next.changeLanguage(lang, () => {
-      updateContent();
-      updateLinks();
-    });
+    // Reload the page so that any JavaScript-generated content is refreshed
+    // in the newly selected language.
+    window.location.reload();
   }
 
   function changeTheme(theme) {


### PR DESCRIPTION
## Summary
- Force full page reload when the language selection changes to ensure all dynamically generated content updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893de791a1c8321a80e71db2b6e03bb