### PR TITLE
Enhance copy week button with icons and feedback

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -30,5 +30,6 @@
   "light": "Light",
   "dark": "Dark",
   "menu": "Menu",
-  "copy_week": "Copy week"
+  "copy_week": "Copy week",
+  "copied": "Copied"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -30,5 +30,6 @@
   "light": "Claro",
   "dark": "Oscuro",
   "menu": "Men\u00FA",
-  "copy_week": "Copiar semana"
+  "copy_week": "Copiar semana",
+  "copied": "Copiado"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -30,5 +30,6 @@
   "light": "Claro",
   "dark": "Escuro",
   "menu": "Menu",
-  "copy_week": "Copiar semana"
+  "copy_week": "Copiar semana",
+  "copied": "Copiado"
 }

--- a/script.js
+++ b/script.js
@@ -404,7 +404,7 @@ function renderEventsList(events, startDateInput, endDateInput) {
     });
     const copyText = encodeURIComponent(lines.join('\n'));
     html.push(
-      `<h3>${rangeText} <a href="#" onclick="copyWeek('${copyText}'); return false;">${T.copy_week}</a></h3>`
+      `<h3>${rangeText} <a href="#" onclick="copyWeek('${copyText}', this); return false;" title="${T.copy_week}" style="font-size:0.75em;margin-left:0.5em;">📋 ${T.copy_week}</a></h3>`
     );
     html.push('<ol>');
     html.push(...itemsHtml);
@@ -413,10 +413,21 @@ function renderEventsList(events, startDateInput, endDateInput) {
   return html.join('');
 }
 
-function copyWeek(encoded) {
+function copyWeek(encoded, linkElement) {
   const text = decodeURIComponent(encoded);
+  const originalHtml = linkElement.innerHTML;
+  const originalTitle = linkElement.title;
+  const showCopied = () => {
+    linkElement.innerHTML = `✅ ${T.copied}`;
+    linkElement.title = T.copied;
+    setTimeout(() => {
+      linkElement.innerHTML = originalHtml;
+      linkElement.title = originalTitle;
+    }, 2000);
+  };
+
   if (navigator.clipboard && navigator.clipboard.writeText) {
-    navigator.clipboard.writeText(text);
+    navigator.clipboard.writeText(text).then(showCopied);
   } else {
     const textarea = document.createElement('textarea');
     textarea.value = text;
@@ -424,6 +435,7 @@ function copyWeek(encoded) {
     textarea.select();
     document.execCommand('copy');
     document.body.removeChild(textarea);
+    showCopied();
   }
 }
 


### PR DESCRIPTION
## Summary
- Add clipboard icon and smaller styling for the Copy week button
- Show a checkmark with translated 'Copied' label after copying
- Localize new `copied` string in English, Spanish and Portuguese

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e0a1f644832197944fdc70a98862