### PR TITLE
Add external literary resources menu link

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,9 +61,15 @@
       { href: 'availability.html', key: 'availability' },
       { href: 'teaching.html', key: 'teaching' },
       { href: 'this_week.html', key: 'this_week' },
-      { href: 'next_week.html', key: 'next_week' }
+      { href: 'next_week.html', key: 'next_week' },
+      { href: 'https://jesusyyo.com/', key: 'resources', external: true }
     ];
-    const menuLinks = menuItems.map(i => `<li><a href="${i.href}" data-i18n-key="${i.key}"></a></li>`).join('');
+    const menuLinks = menuItems
+      .map(i => {
+        const attrs = `href="${i.href}"${i.external ? ' target="_blank" rel="noopener noreferrer"' : ''}`;
+        return `<li><a ${attrs} data-i18n-key="${i.key}"></a></li>`;
+      })
+      .join('');
     const header = document.createElement('header');
     header.innerHTML = `
       <div style="display:flex;justify-content:space-between;align-items:center;">

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <li><a href="teaching.html" data-i18n-key="teaching"></a></li>
     <li><a href="this_week.html" data-i18n-key="this_week"></a></li>
     <li><a href="next_week.html" data-i18n-key="next_week"></a></li>
+    <li><a href="https://jesusyyo.com/" target="_blank" rel="noopener noreferrer" data-i18n-key="resources"></a></li>
   </ul>
 </body>
 </html>

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,6 +5,7 @@
   "teaching": "\uD83D\uDCCD Where is MAWC taking place in this date range?",
   "this_week": "\uD83D\uDCC6 MAWC This Week",
   "next_week": "\uD83D\uDD1C MAWC Next Week",
+  "resources": "\uD83D\uDCD4 Useful Literary Resources",
   "home": "\uD83C\uDFE0 Home",
   "site_title": "Moments alone with Christ",
   "select_date": "Select date range:",

--- a/locales/es.json
+++ b/locales/es.json
@@ -5,6 +5,7 @@
   "teaching": "\uD83D\uDCCD \u00BFD\u00F3nde se realiza MASCC en este intervalo de fechas?",
   "this_week": "\uD83D\uDCC6 MASCC Esta Semana",
   "next_week": "\uD83D\uDD1C MASCC La Pr\u00F3xima Semana",
+  "resources": "\uD83D\uDCD4 Recursos Literarios \u00DAtiles",
   "home": "\uD83C\uDFE0 Inicio",
   "site_title": "Momentos a solas con Cristo",
   "select_date": "Selecciona un rango de fechas:",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -5,6 +5,7 @@
   "teaching": "\uD83D\uDCCD Onde h\u00E1 MASCC nesse intervalo de datas?",
   "this_week": "\uD83D\uDCC6 MASCC Esta Semana",
   "next_week": "\uD83D\uDD1C MASCC Pr\u00F3xima Semana",
+  "resources": "\uD83D\uDCD4 Recursos Liter\u00E1rios \u00DAteis",
   "home": "\uD83C\uDFE0 In\u00EDcio",
   "site_title": "Momentos a s\u00F3s com Cristo",
   "select_date": "Selecione o intervalo de datas:",


### PR DESCRIPTION
## Summary
- add "📚 Useful Literary Resources" link to homepage and global menu
- translate resources label for English, Spanish, Portuguese

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e31495bc8321b3236fd9d9221c6c