### PR TITLE
Normalize speaker language codes and localize display

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,6 +13,17 @@ function getFollowUrl(calendarId) {
   return `https://calendar.google.com/calendar/ical/${encodeURIComponent(calendarId)}/public/basic.ics`;
 }
 
+function formatLanguages(languages) {
+  if (!languages || !languages.length) return '';
+  try {
+    const lang = typeof i18next !== 'undefined' && i18next.language ? i18next.language : 'en';
+    const display = new Intl.DisplayNames([lang], { type: 'language' });
+    return languages.map(code => display.of(code) || code).join(', ');
+  } catch (e) {
+    return languages.join(', ');
+  }
+}
+
 async function speakers() {
   if (!speakersCache) {
     const res = await fetch('speakers.json');
@@ -64,7 +75,7 @@ async function checkAvailability() {
             ? `<br/>${flagEmoji(normalizedCountryCode)} ${parts}`
             : '';
           const langs = languages && languages.length
-            ? `<br/>🗣️ ${languages.join(', ')}`
+            ? `<br/>🗣️ ${formatLanguages(languages)}`
             : '';
           const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?key=${API_KEY}&timeMin=${timeMin}&timeMax=${timeMax}&singleEvents=true&orderBy=startTime`;
 
@@ -151,7 +162,7 @@ async function checkAvailability() {
           ? `<br/>${flagEmoji(normalizedCountryCode)} ${parts}`
           : '';
         const langs = languages && languages.length
-          ? `<br/>🗣️ ${languages.join(', ')}`
+          ? `<br/>🗣️ ${formatLanguages(languages)}`
           : '';
         const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?key=${API_KEY}&timeMin=${timeMin}&timeMax=${timeMax}&singleEvents=true&orderBy=startTime`;
 
@@ -555,6 +566,7 @@ if (typeof window !== 'undefined') {
   window.checkTeaching = checkTeaching;
   window.addEventListener('DOMContentLoaded', syncInputsWithUrl);
   window.copyWeek = copyWeek;
+  window.formatLanguages = formatLanguages;
 }
 
 export {
@@ -571,5 +583,6 @@ export {
   checkTeaching,
   setRangeText,
   copyWeek,
-  API_KEY
+  API_KEY,
+  formatLanguages
 };

--- a/speaker.html
+++ b/speaker.html
@@ -21,7 +21,8 @@
       getFollowUrl,
       flagEmoji,
       formatDisplayDate,
-      API_KEY
+      API_KEY,
+      formatLanguages
     } from './script.js';
     import { getCountryCode } from './countryCodeLookup.js';
 
@@ -41,7 +42,7 @@
 
       const calendarLinks = `<a href="${getCalendarUrl(sp.calendarId)}" target="_blank">${T.view_calendar}</a> | <a href="${getFollowUrl(sp.calendarId)}" target="_blank">${T.follow_calendar}</a>`;
       const location = sp.location ? `<br/>${flagEmoji(sp.normalizedCountryCode)} ${sp.location}` : '';
-      const langs = sp.languages ? `<br/>🗣️ ${sp.languages.join(', ')}` : '';
+      const langs = sp.languages && sp.languages.length ? `<br/>🗣️ ${formatLanguages(sp.languages)}` : '';
       const requestLink = sp.formUrl ? `<br/><a href="${sp.formUrl}" target="_blank">${T.request_speaker}</a>` : '';
       document.getElementById('speakerInfo').innerHTML = `${location}${langs}<br/>${calendarLinks}${requestLink}`;
 

--- a/speakers.html
+++ b/speakers.html
@@ -13,7 +13,7 @@
   <h1 data-i18n-key="list"></h1>
   <ul id="speakerList"></ul>
   <script type="module">
-    import { speakers, getCalendarUrl, getFollowUrl, flagEmoji } from './script.js';
+    import { speakers, getCalendarUrl, getFollowUrl, flagEmoji, formatLanguages } from './script.js';
 
     const render = () => {
       speakers().then(data => {
@@ -22,7 +22,7 @@
           const name = `<strong><a href="speaker.html?id=${speaker.id}">${speaker.name}</a></strong>`;
           const calendarLinks = `<a href="${getCalendarUrl(speaker.calendarId)}" target="_blank">${T.view_calendar}</a> | <a href="${getFollowUrl(speaker.calendarId)}" target="_blank">${T.follow_calendar}</a>`;
           const location = speaker.location ? `<br/>${flagEmoji(speaker.normalizedCountryCode)} ${speaker.location}` : '';
-          const langs = speaker.languages ? `<br/>🗣️ ${speaker.languages.join(', ')}` : '';
+          const langs = speaker.languages && speaker.languages.length ? `<br/>🗣️ ${formatLanguages(speaker.languages)}` : '';
           const requestLink = speaker.formUrl ? `<br/><a href="${speaker.formUrl}" target="_blank">${T.request_speaker}</a>` : '';
           const li = document.createElement('li');
           li.innerHTML = `${name}${location}${langs}<br/>${calendarLinks}${requestLink}`;

--- a/speakers.json
+++ b/speakers.json
@@ -5,7 +5,7 @@
     "calendarId": "0ca7e99a558f60e928a3e775ab8d5bf0949630d14a37f2ae542646411f569044@group.calendar.google.com",
     "location": "Paranaíba, MS, Brasil",
     "normalizedCountryCode": "BR",
-    "languages": ["Português", "Español"],
+    "languages": ["pt", "es"],
     "formUrl": "https://forms.gle/FCcjntfuuoGoGLtx5"
   },
   {
@@ -14,7 +14,7 @@
     "calendarId": "47d6c4ce5a6c1efcce8f7a40abaf38ad59995d62194d27170aba63b1bd184dd8@group.calendar.google.com",
     "location": "Bothell, WA, USA",
     "normalizedCountryCode": "US",
-    "languages": ["English", "Español", "Português"],
+    "languages": ["en", "es", "pt"],
     "formUrl": "https://forms.gle/8y8kycv8ZFndSmAc6"
   },
   {
@@ -23,7 +23,7 @@
     "calendarId": "f5ce6655ed5feb654a23a79d2dda755debd873372ec8353551b972c5cb747c61@group.calendar.google.com",
     "location": "Brasília, DF, Brasil",
     "normalizedCountryCode": "BR",
-    "languages": ["Português"],
+    "languages": ["pt"],
     "formUrl": "https://forms.gle/bVL1ByhmG4wbAMKb7"
   },
   {
@@ -32,7 +32,7 @@
     "calendarId": "c79d0abe72d68b4ea0eb7e671c45e84eaccd41b959eab558761c04dda2ffe9ac@group.calendar.google.com",
     "location": "Moquegua, Perú",
     "normalizedCountryCode": "PE",
-    "languages": ["Español", "Português"],
+    "languages": ["es", "pt"],
     "formUrl": "https://forms.gle/gAJFxmU3XBBwVFrP6"
   },
   {
@@ -41,7 +41,7 @@
     "calendarId": "deb8969c4b0637ca9008efe6ca694631142f43b88c70c533eb2c34808c1e75ec@group.calendar.google.com",
     "location": "Moquegua, Perú",
     "normalizedCountryCode": "PE",
-    "languages": ["Español", "Português"],
+    "languages": ["es", "pt"],
     "formUrl": "https://forms.gle/DVGmCpqH4QDmjFP58"
   },
   {
@@ -50,7 +50,7 @@
     "calendarId": "4667389ecf273bdcbe538106ec17c410f08bfc68f853e91e14e31ad303059aea@group.calendar.google.com",
     "location": "Moquegua, Perú",
     "normalizedCountryCode": "PE",
-    "languages": ["Español"],
+    "languages": ["es"],
     "formUrl": "https://forms.gle/kRExifPWRfFdgkts5"
   },
   {
@@ -59,7 +59,7 @@
     "calendarId": "6a1c50d5b87b24787c01131ee7f6abd2aa8b8284f2966dbf1e0531f6514e8d8d@group.calendar.google.com",
     "location": "Moquegua, Perú",
     "normalizedCountryCode": "PE",
-    "languages": ["Español"],
+    "languages": ["es"],
     "formUrl": "https://forms.gle/TYnna4sFNLTETtMc6"
   },
   {
@@ -68,7 +68,7 @@
     "calendarId": "54e0b886bae92e14236e2823f424df52bc0ee1fb2b0b3afcdeb612b6fcca1d16@group.calendar.google.com",
     "location": "Quatro Barras, PR, Brasil",
     "normalizedCountryCode": "BR",
-    "languages": ["Português"],
+    "languages": ["pt"],
     "formUrl": "https://docs.google.com/forms/d/e/1FAIpQLSfg7FwEokvUPHs5n_FVcaOG7drzc7NJw4MLZmaUqThobYpQfg/viewform"
   },
   {
@@ -77,7 +77,7 @@
     "calendarId": "0603a19b52adaa2dcfbd4a9de8384a2650c615a4d0bad740f781ada2233c9aa2@group.calendar.google.com",
     "location": "Campo Grande, MS, Brasil",
     "normalizedCountryCode": "BR",
-    "languages": ["Español", "Português"],
+    "languages": ["es", "pt"],
     "formUrl": "https://docs.google.com/forms/d/e/1FAIpQLSeuAa92Pfq3YSr3bAetd9-h5yM4mX5pavDDutjNV9xBmv4ySg/viewform"
   },
   {
@@ -86,7 +86,7 @@
     "calendarId": "6b4b3fc3eb9b094732ca21cf7f6dd4c32103350233579b57add7df5893b7d7da@group.calendar.google.com",
     "location": "Saõ Paulo / Hortolândia (ambos), SP, Brasil",
     "normalizedCountryCode": "BR",
-    "languages": ["Português"],
+    "languages": ["pt"],
     "formUrl": "https://docs.google.com/forms/d/e/1FAIpQLSdPWWWZ2OvADEihWamlO7lPVekhzQku0R7U0hGb4JHibfzXXw/viewform"
   },
   {
@@ -95,7 +95,7 @@
     "calendarId": "cddf180922a4bc1c07833bb34e68143205deef34bc7c60c14db6eec8331ecf4f@group.calendar.google.com",
     "location": "Taubaté, SP, Brasil",
     "normalizedCountryCode": "BR",
-    "languages": ["Português"],
+    "languages": ["pt"],
     "formUrl": "https://forms.gle/aLuFSeyrD56ML1Fi7"
   }
 ]


### PR DESCRIPTION
## Summary
- store speaker languages using ISO codes
- display language names according to page locale

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68963bdd229483218117bf7919a7581d