### PR TITLE
Add children teaching group filters and lists

### DIFF
--- a/availability.html
+++ b/availability.html
@@ -21,6 +21,16 @@
     <span data-i18n-key="must_be_available_entire_range"></span>
   </label>
   <br />
+  <label>
+    <input type="checkbox" id="children6to8" />
+    <span data-i18n-key="must_teach_children_6_8"></span>
+  </label>
+  <br />
+  <label>
+    <input type="checkbox" id="children9to12" />
+    <span data-i18n-key="must_teach_children_9_12"></span>
+  </label>
+  <br />
   <button onclick="checkAvailability()" data-i18n-key="check"></button>
   <div id="results"></div>
   <p id="regionalNote" data-i18n-key="regional_availability_note" style="display:none;"></p>

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,6 +23,8 @@
   "view_calendar": "View Calendar",
   "follow_calendar": "Follow Calendar",
   "must_be_available_entire_range": "Must be available for the entire range",
+  "must_teach_children_6_8": "Must be able to teach to children 6 to 8 years old",
+  "must_teach_children_9_12": "Must be able to teach to children 9 to 12 years old",
   "none_available": "No speakers available",
   "document_link": "https://docs.google.com/document/d/1DA43ee8d6fvvf8PvauI7GbMJQ_Tyzd_e1ie6qB72zhY/",
   "document_description": "How to schedule MAWC",
@@ -35,5 +37,7 @@
   "menu": "Menu",
   "copy_week": "Copy week",
   "copied": "Copied",
-  "scheduled_mawcs": "Scheduled MAWCs"
+  "scheduled_mawcs": "Scheduled MAWCs",
+  "children_6_8_speakers": "Speakers who can teach children 6 to 8 years old",
+  "children_9_12_speakers": "Speakers who can teach children 9 to 12 years old"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -23,6 +23,8 @@
   "view_calendar": "Ver Calendario",
   "follow_calendar": "Seguir Calendario",
   "must_be_available_entire_range": "Debe estar disponible durante todo el rango",
+  "must_teach_children_6_8": "Debe poder enseñar a niños de 6 a 8 años",
+  "must_teach_children_9_12": "Debe poder enseñar a niños de 9 a 12 años",
   "none_available": "No hay oradores disponibles",
   "document_link": "https://docs.google.com/document/d/12r9yETGDjLMo9Nb8zbbkT4BreQrCAEy9mfirN-b7_cE/",
   "document_description": "C\u00F3mo agendar MASCC",
@@ -35,5 +37,7 @@
   "menu": "Men\u00FA",
   "copy_week": "Copiar semana",
   "copied": "Copiado",
-  "scheduled_mawcs": "MASCCs agendados"
+  "scheduled_mawcs": "MASCCs agendados",
+  "children_6_8_speakers": "Oradores que pueden enseñar a niños de 6 a 8 años",
+  "children_9_12_speakers": "Oradores que pueden enseñar a niños de 9 a 12 años"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -23,6 +23,8 @@
   "view_calendar": "Ver Calend\u00E1rio",
   "follow_calendar": "Seguir Calend\u00E1rio",
   "must_be_available_entire_range": "Deve estar dispon\u00EDvel durante todo o intervalo",
+  "must_teach_children_6_8": "Deve ser capaz de ensinar crian\u00E7as de 6 a 8 anos",
+  "must_teach_children_9_12": "Deve ser capaz de ensinar crian\u00E7as de 9 a 12 anos",
   "none_available": "Nenhum orador dispon\u00EDvel",
   "document_link": "https://docs.google.com/document/d/1-j6IjAytS1a-RnwRNrzXyqbqcEDxUwDz2IBwrke2O1s/",
   "document_description": "Como agendar MASCC",
@@ -35,5 +37,7 @@
   "menu": "Menu",
   "copy_week": "Copiar semana",
   "copied": "Copiado",
-  "scheduled_mawcs": "MASCCs agendados"
+  "scheduled_mawcs": "MASCCs agendados",
+  "children_6_8_speakers": "Oradores que podem ensinar crian\u00E7as de 6 a 8 anos",
+  "children_9_12_speakers": "Oradores que podem ensinar crian\u00E7as de 9 a 12 anos"
 }

--- a/script.js
+++ b/script.js
@@ -41,6 +41,8 @@ async function checkAvailability() {
   const startDateInput = document.getElementById('startDate').value;
   const endDateInput = document.getElementById('endDate').value;
   const mustBeEntireRange = document.getElementById('entireRange')?.checked;
+  const mustTeachChildren6to8 = document.getElementById('children6to8')?.checked;
+  const mustTeachChildren9to12 = document.getElementById('children9to12')?.checked;
   if (!startDateInput || !endDateInput) return;
 
   const startDate = new Date(startDateInput);
@@ -55,7 +57,10 @@ async function checkAvailability() {
   const timeMin = bufferedStart.toISOString();
   const timeMax = bufferedEnd.toISOString();
 
-  const sp = await speakers();
+  const allSpeakers = await speakers();
+  let sp = allSpeakers;
+  if (mustTeachChildren6to8) sp = sp.filter(s => s.children6to8);
+  if (mustTeachChildren9to12) sp = sp.filter(s => s.children9to12);
 
   const resultsDiv = document.getElementById('results');
   const noteEl = document.getElementById('regionalNote');

--- a/speakers.html
+++ b/speakers.html
@@ -12,12 +12,18 @@
 <body>
   <h1 data-i18n-key="list"></h1>
   <ul id="speakerList"></ul>
+  <h2 data-i18n-key="children_6_8_speakers"></h2>
+  <ul id="children6to8List"></ul>
+  <h2 data-i18n-key="children_9_12_speakers"></h2>
+  <ul id="children9to12List"></ul>
   <script type="module">
     import { speakers, getCalendarUrl, getFollowUrl, flagEmoji, formatLanguages } from './script.js';
 
     const render = () => {
       speakers().then(data => {
         const ul = document.getElementById('speakerList');
+        const kids6to8Ul = document.getElementById('children6to8List');
+        const kids9to12Ul = document.getElementById('children9to12List');
         data.forEach(speaker => {
           const name = `<strong><a href="speaker.html?id=${speaker.id}">${speaker.name}</a></strong>`;
           const calendarLinks = `<a href="${getCalendarUrl(speaker.calendarId)}" target="_blank">${T.view_calendar}</a> | <a href="${getFollowUrl(speaker.calendarId)}" target="_blank">${T.follow_calendar}</a>`;
@@ -27,6 +33,16 @@
           const li = document.createElement('li');
           li.innerHTML = `${name}${location}${langs}<br/>${calendarLinks}${requestLink}`;
           ul.appendChild(li);
+          if (speaker.children6to8) {
+            const li6 = document.createElement('li');
+            li6.innerHTML = `${name}${location}${langs}<br/>${calendarLinks}${requestLink}`;
+            kids6to8Ul.appendChild(li6);
+          }
+          if (speaker.children9to12) {
+            const li9 = document.createElement('li');
+            li9.innerHTML = `${name}${location}${langs}<br/>${calendarLinks}${requestLink}`;
+            kids9to12Ul.appendChild(li9);
+          }
         });
       });
     };

--- a/speakers.json
+++ b/speakers.json
@@ -24,7 +24,9 @@
     "location": "Brasília, DF, Brasil",
     "normalizedCountryCode": "BR",
     "languages": ["pt"],
-    "formUrl": "https://forms.gle/bVL1ByhmG4wbAMKb7"
+    "formUrl": "https://forms.gle/bVL1ByhmG4wbAMKb7",
+    "children6to8": true,
+    "children9to12": true
   },
   {
     "id": 4,
@@ -33,7 +35,9 @@
     "location": "Moquegua, Perú",
     "normalizedCountryCode": "PE",
     "languages": ["es", "pt"],
-    "formUrl": "https://forms.gle/gAJFxmU3XBBwVFrP6"
+    "formUrl": "https://forms.gle/gAJFxmU3XBBwVFrP6",
+    "children6to8": true,
+    "children9to12": true
   },
   {
     "id": 5,
@@ -42,7 +46,9 @@
     "location": "Moquegua, Perú",
     "normalizedCountryCode": "PE",
     "languages": ["es", "pt"],
-    "formUrl": "https://forms.gle/DVGmCpqH4QDmjFP58"
+    "formUrl": "https://forms.gle/DVGmCpqH4QDmjFP58",
+    "children6to8": true,
+    "children9to12": true
   },
   {
     "id": 6,
@@ -96,6 +102,8 @@
     "location": "Taubaté, SP, Brasil",
     "normalizedCountryCode": "BR",
     "languages": ["pt"],
-    "formUrl": "https://forms.gle/aLuFSeyrD56ML1Fi7"
+    "formUrl": "https://forms.gle/aLuFSeyrD56ML1Fi7",
+    "children6to8": true,
+    "children9to12": true
   }
 ]


### PR DESCRIPTION
## Summary
- Mark speakers who can teach children aged 6–8 and 9–12
- Add age group sections to speakers listing
- Filter availability by required children's age groups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689643e63f9483219af73791f36fbc3b